### PR TITLE
Print Entire Docker output to window

### DIFF
--- a/fzf-docker.plugin.zsh
+++ b/fzf-docker.plugin.zsh
@@ -25,7 +25,7 @@ _fzf_complete_docker() {
     _fzf_complete "--multi --header-lines=1" "$@" < <(
       docker images --format "table {{.ID}}\t{{.Repository}}\t{{.Tag}}\t{{.Size}}"
     )
-  elif [[ $ARGS == 'docker stop'* || $ARGS == 'docker rm'* || $ARGS == 'docker exec'* || $ARGS == 'docker kill'* ]]; then
+  elif [[ $ARGS == 'docker stop'* || $ARGS == 'docker rm'* || $ARGS == 'docker exec'* || $ARGS == 'docker kill'* || $ARGS == 'docker start'* || $ARGS == 'docker restart'* ]]; then
     _fzf_complete "--multi --header-lines=1 " "$@" < <(
       docker ps
     )

--- a/fzf-docker.plugin.zsh
+++ b/fzf-docker.plugin.zsh
@@ -17,9 +17,13 @@ _fzf_complete_docker() {
     _fzf_complete "--reverse -n 1 --height=80%" "$@" < <(
       echo $DOCKER_COMMANDS
     )
-  elif [[ $ARGS == 'docker rmi'* || $ARGS == 'docker tag'* || $ARGS == 'docker -f'* || $ARGS == 'docker run'* || $ARGS == 'docker push'* ]]; then
+  elif [[ $ARGS == 'docker tag'* || $ARGS == 'docker -f'* || $ARGS == 'docker run'* || $ARGS == 'docker push'* ]]; then
     _fzf_complete "--multi --header-lines=1" "$@" < <(
-      docker images
+      docker images --format "table {{.Repository}}:{{.Tag}}\t{{.Size}}\t{{.ID}}\t{{.CreatedSince}}"
+    )
+  elif [[ $ARGS == 'docker rmi'* ]]; then
+    _fzf_complete "--multi --header-lines=1" "$@" < <(
+      docker images --format "table {{.ID}}\t{{.Repository}}\t{{.Tag}}\t{{.Size}}"
     )
   elif [[ $ARGS == 'docker stop'* || $ARGS == 'docker rm'* || $ARGS == 'docker exec'* || $ARGS == 'docker kill'* ]]; then
     _fzf_complete "--multi --header-lines=1 " "$@" < <(

--- a/fzf-docker.plugin.zsh
+++ b/fzf-docker.plugin.zsh
@@ -17,13 +17,13 @@ _fzf_complete_docker() {
     _fzf_complete "--reverse -n 1 --height=80%" "$@" < <(
       echo $DOCKER_COMMANDS
     )
-  elif [[ $ARGS == 'docker rmi'* || $ARGS == 'docker -f'* ]]; then
-    _fzf_complete "--multi --reverse" "$@" < <(
-      docker images --format '{{.Repository}}:{{.Tag}}'
+  elif [[ $ARGS == 'docker rmi'* || $ARGS == 'docker tag'* || $ARGS == 'docker -f'* || $ARGS == 'docker run'* || $ARGS == 'docker push'* ]]; then
+    _fzf_complete "--multi --header-lines=1" "$@" < <(
+      docker images
     )
-  elif [[ $ARGS == 'docker start'* || $ARGS == 'docker restart'* || $ARGS == 'docker stop'* || $ARGS == 'docker rm'* || $ARGS == 'docker exec'* || $ARGS == 'docker kill'* ]]; then
-    _fzf_complete "--multi --reverse" "$@" < <(
-      docker ps --format '{{.Names}}'
+  elif [[ $ARGS == 'docker stop'* || $ARGS == 'docker rm'* || $ARGS == 'docker exec'* || $ARGS == 'docker kill'* ]]; then
+    _fzf_complete "--multi --header-lines=1 " "$@" < <(
+      docker ps
     )
   fi
 }


### PR DESCRIPTION
The TLDR is that the content will not print as if someone had called `docker images` or `docker container ls`

This'll follow the standard fzf rules. You could start typing and if you match _anything_ in the line, it'll use whatever value is in the first column

<img width="687" alt="Screen Shot 2019-12-18 at 11 33 13 AM" src="https://user-images.githubusercontent.com/6912711/71117190-82177400-218a-11ea-93ac-13341cd120a8.png">
<img width="804" alt="Screen Shot 2019-12-18 at 11 33 44 AM" src="https://user-images.githubusercontent.com/6912711/71117198-8479ce00-218a-11ea-8624-9393e1024140.png">
<img width="1521" alt="Screen Shot 2019-12-18 at 11 35 01 AM" src="https://user-images.githubusercontent.com/6912711/71117200-86439180-218a-11ea-97ea-2a8d1a9d5359.png">
