### PR TITLE
Fixed docker rm ** not showing stopped container

### DIFF
--- a/fzf-docker.plugin.zsh
+++ b/fzf-docker.plugin.zsh
@@ -34,7 +34,7 @@ _fzf_complete_docker() {
     )
   elif [[ $ARGS == 'docker rm'* ]]; then
     _fzf_complete "--multi --header-lines=1 " "$@" < <(
-      docker ps -a | grep Exit --format "${FZF_DOCKER_PS_FORMAT}"
+      docker ps -a --format "${FZF_DOCKER_PS_FORMAT}"
   )
   elif [[ $ARGS == 'docker start'* ]]; then
      _fzf_complete "--multi --header-lines=1 " "$@" < <(

--- a/fzf-docker.plugin.zsh
+++ b/fzf-docker.plugin.zsh
@@ -32,7 +32,7 @@ _fzf_complete_docker() {
     _fzf_complete "--multi --header-lines=1 " "$@" < <(
       docker ps --format "${FZF_DOCKER_PS_FORMAT}"
     )
-  elif [[ $ARGS == 'docker rm'*]]; then
+  elif [[ $ARGS == 'docker rm'* ]]; then
     _fzf_complete "--multi --header-lines=1 " "$@" < <(
       docker ps -a | grep Exit --format "${FZF_DOCKER_PS_FORMAT}"
   )

--- a/fzf-docker.plugin.zsh
+++ b/fzf-docker.plugin.zsh
@@ -28,10 +28,14 @@ _fzf_complete_docker() {
     _fzf_complete "--multi --header-lines=1" "$@" < <(
       docker images --format "table {{.ID}}\t{{.Repository}}\t{{.Tag}}\t{{.Size}}"
     )
-  elif [[ $ARGS == 'docker stop'* || $ARGS == 'docker rm'* || $ARGS == 'docker exec'* || $ARGS == 'docker kill'* || $ARGS == 'docker restart'* || $ARGS == 'docker logs'* ]]; then
+  elif [[ $ARGS == 'docker stop'* || $ARGS == 'docker exec'* || $ARGS == 'docker kill'* || $ARGS == 'docker restart'* || $ARGS == 'docker logs'* ]]; then
     _fzf_complete "--multi --header-lines=1 " "$@" < <(
       docker ps --format "${FZF_DOCKER_PS_FORMAT}"
     )
+  elif [[ $ARGS == 'docker rm'*]]; then
+    _fzf_complete "--multi --header-lines=1 " "$@" < <(
+      docker ps -a | grep Exit --format "${FZF_DOCKER_PS_FORMAT}"
+  )
   elif [[ $ARGS == 'docker start'* ]]; then
      _fzf_complete "--multi --header-lines=1 " "$@" < <(
       docker ps -a --format "${FZF_DOCKER_PS_START_FORMAT}"


### PR DESCRIPTION
Loved the plugin, but noticed that docker rm ** is not working correctly for me. I just added an additional elif for "docker rm" to execute docker ps -a instead of docker ps. This makes sure, that all containers are shown. Additionally, docker rm can not remove running containers, so the command was changed to "docker ps -a | grep Exit". This way, the completion for rm works and only shows containers, which are exited and therefore removed.