### PR TITLE
Preview docker logs with arrows

### DIFF
--- a/fzf-docker.plugin.zsh
+++ b/fzf-docker.plugin.zsh
@@ -28,9 +28,13 @@ _fzf_complete_docker() {
     _fzf_complete "--multi --header-lines=1" "$@" < <(
       docker images --format "table {{.ID}}\t{{.Repository}}\t{{.Tag}}\t{{.Size}}"
     )
-  elif [[ $ARGS == 'docker stop'* || $ARGS == 'docker exec'* || $ARGS == 'docker kill'* || $ARGS == 'docker restart'* || $ARGS == 'docker logs'* ]]; then
+  elif [[ $ARGS == 'docker stop'* || $ARGS == 'docker exec'* || $ARGS == 'docker kill'* || $ARGS == 'docker restart'* ]]; then
     _fzf_complete "--multi --header-lines=1 " "$@" < <(
       docker ps --format "${FZF_DOCKER_PS_FORMAT}"
+    )  
+  elif [[ $ARGS == 'docker logs'* ]]; then
+    _fzf_complete "--multi --header-lines=1 --header 'Enter CTRL-O to open log in editor | CTRL-/ to change height\n\n' --bind 'ctrl-/:change-preview-window(80%,border-bottom|)' --bind \"ctrl-o:execute:docker logs {1} | sed 's/\x1b\[[0-9;]*m//g' | cat | ${EDITOR:-vim} -\" --preview-window up:follow --preview 'docker logs --follow --tail=100 {1}' " "$@" < <(
+      docker ps -a --format "${FZF_DOCKER_PS_FORMAT}"
     )
   elif [[ $ARGS == 'docker rm'* ]]; then
     _fzf_complete "--multi --header-lines=1 " "$@" < <(


### PR DESCRIPTION
Support preview docker logs while moving. 

- Expand preview with `ctrl-/`
- Open docker logs output with `ctrl+o`

![docker](https://github.com/user-attachments/assets/881ad62d-b0ed-4470-b888-bb9869b1e72b)
